### PR TITLE
Updated OSX command to use lower case 'w'

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Both files can be downloaded from here https://docs.aws.amazon.com/deepracer/lat
 **Command**:
 
 ```
-./usb-build.sh -d disk2 -s <WIFI_SSID> -W <WIFI_PASSWORD>
+./usb-build.sh -d disk2 -s <WIFI_SSID> -w <WIFI_PASSWORD>
 ```
 
 **Note:**


### PR DESCRIPTION
Fixed the example OSX command for build to use lowercase 'w' as it wasn't running with capital 'W'